### PR TITLE
Add clock in feature

### DIFF
--- a/keymaps/tasks.cson
+++ b/keymaps/tasks.cson
@@ -12,9 +12,11 @@
   'cmd-d': 'tasks:complete'
   'cmd-a': 'tasks:archive'
   'ctrl-c': 'tasks:cancel'
+  'alt-t': 'tasks:clock'
 
 '.platform-win32 atom-workspace atom-text-editor:not(.mini)[data-grammar~="todo"], .platform-linux atom-workspace atom-text-editor:not(.mini)[data-grammar~="todo"]':
   'ctrl-enter': 'tasks:add'
   'ctrl-d': 'tasks:complete'
   'ctrl-shift-a': 'tasks:archive'
   'alt-c': 'tasks:cancel'
+  'alt-t': 'tasks:clock'

--- a/menus/tasks.cson
+++ b/menus/tasks.cson
@@ -21,5 +21,9 @@
       'label': 'Cancel Task',
       'command': 'tasks:cancel'
     }
+    {
+      'label': 'Clock Task'
+      'command': 'tasks:clock'
+    }
     {'type': 'separator'}
   ]

--- a/styles/tasks.less
+++ b/styles/tasks.less
@@ -18,6 +18,11 @@ atom-text-editor::shadow, atom-text-editor {
       &.attribute { color: darken(@text-color-info, 20%); }
     }
 
-    &.cancelled.marker { color: @text-color-error; }
+    &.time { color: darken(@text-color-info, 20%); }
+    
+    &.clock,
+    &.cancelled.marker {
+      color: @text-color-error;
+    }
   }
 }


### PR DESCRIPTION
This commit set adds the capability to clock in to tasks.
You can clock in and clock out, the time will be summed up.
Automatically clock out when running done or cancel.

Running the clock command on a task:
```
☐ foobar
☐ foobar @clock(2015-02-12 22:53)  // run clock (clock in)
☐ foobar @time(0.0:2) // run clock after 2 min time stamp d.hh.mm (clock out)
☐ foobar @time(0.0:2) @clock(2015-02-12 22:57) // run clock (clock in again)
✔ foobar @time(0.0:4) @done(2015-02-12 22:59) // run done after 2 min, time gets added 
```

Have a look at the OS X key binding, you may have a better idea. I don't know if ctrl-t will work, it's alt-t atm.
And have a look at the tasks.less `@clock` should be red (error) and `@time` subtle.

I didn't modify the patterns in the tasks.cson in the lib dir, do i need to add something there?

Maybe it comes in handy,
have a nice day.