### PR TITLE
archive: Replace ＿ with _ (underscore), fixes #27

### DIFF
--- a/lib/tasks.coffee
+++ b/lib/tasks.coffee
@@ -320,7 +320,7 @@ module.exports =
         archiveText = """
 
 
-        ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿
+        _____________________
         Archive:
 
         """


### PR DESCRIPTION
Atom suffers from the font problems when using non standard characters.
The task indicators are configurable in atom-tasks, so one is able to fix
broken fonts.

The archive overline is hardcoded in atom-tasks. Since an underscore `_`
looks quite the same as `＿`, let's fix that problem.

see also:
* https://github.com/irrationalistic/atom-tasks/issues/27
* https://github.com/atom/atom/issues/6435
* https://github.com/atom/atom/issues/6214