### PR TITLE
escape parens in tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.7.0
+* Adds setting for applying timestamp when an item is converted to task (#76)
+* Re-enabled and updated all tests
+* Fix markdown in text
+* Fix completion count in taskbar (#82)
+* Updated moment version
+
 ## 2.6.7
 * Fixes #78 (thanks @stefanthaler and @Guerillero)
 

--- a/lib/tasks.coffee
+++ b/lib/tasks.coffee
@@ -28,6 +28,8 @@ module.exports =
       type: 'string', default: '＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿'
     attributeMarker:
       type: 'string', default: '@'
+    addTimestampOnConvertToTask:
+      type: 'boolean', default: false
 
 
 
@@ -298,6 +300,8 @@ module.exports =
           # Only set the marker if this isn't
           # already a task or header.
           tasks.setMarker editor, info, marker
+          if atom.config.get('tasks.addTimestampOnConvertToTask')
+            tasks.addTag editor, row, attributeMarker, 'timestamp', tasks.getFormattedDate()
 
 
   ###*

--- a/lib/tasks.cson
+++ b/lib/tasks.cson
@@ -16,7 +16,7 @@
   {
     'begin': '^([\\s]*)(✔)(?=.*@done)'
     'end': '$'
-    'name': 'tasks.text.done.md'
+    'name': 'tasks.text.done'
     'beginCaptures':
       '2': 'name': 'keyword.tasks.marker'
     'patterns': [
@@ -27,26 +27,25 @@
   {
     'begin': '^([\\s]*)(✘)(?=.*@cancelled)'
     'end': '$'
-    'name': 'tasks.text.cancelled.md'
+    'name': 'tasks.text.cancelled'
     'beginCaptures':
       '2': 'name': 'keyword.tasks.marker'
     'patterns': [
-      {'include': '#marker'}
       {'include': '#attribute'}
     ]
   }
 
   {
-    'match': '^([\\s]*)(☐)((?:(?!:$).)*)$'
-    'name': 'tasks.text.md'
-    'captures':
+    'begin': '^([\\s]*)(☐)'
+    'end': '$'
+    'name': 'tasks.text'
+    'beginCaptures':
       '2': 'name': 'keyword.tasks.marker'
-      '3':
-        'patterns': [
-          {'include': '#attribute'}
-          {'include': 'text.md'}
-          {'include': 'text.hyperlink'}
-        ]
+    'patterns': [
+      {'include': '#attribute'},
+      {'include': 'text.md'}
+      {'include': 'text.hyperlink'}
+    ]
   }
 ]
 

--- a/lib/tasksUtilities.coffee
+++ b/lib/tasksUtilities.coffee
@@ -7,8 +7,8 @@ moment = require 'moment'
 module.exports =
 
   markerSelector: 'keyword.tasks.marker'
-  doneSelector: 'tasks.text.done.source.gfm'
-  cancelledSelector: 'tasks.text.cancelled.source.gfm'
+  doneSelector: 'tasks.text.done'
+  cancelledSelector: 'tasks.text.cancelled'
   archiveSelector: 'control.tasks.header.archive'
   headerSelector: 'control.tasks.header-title'
 
@@ -212,7 +212,7 @@ module.exports =
 
         rowIsZero = editor.indentationForBufferRow(row) is 0
         rowIsEmpty = editor.isBufferRowBlank(row)
-          
+
         break if rowIsZero and not rowIsEmpty
     projects
 

--- a/lib/tasksUtilities.coffee
+++ b/lib/tasksUtilities.coffee
@@ -63,7 +63,7 @@ module.exports =
     # lines = editor.displayBuffer.tokenizedBuffer.tokenizedLines
     # checkLine = lines[lineNumber]
     checkLine = editor.buffer.lineForRow lineNumber
-    attributeRX = new RegExp "( ?)(\\#{attributeMarker}[ ]?(([\\w]+)(\\((.*?)\\))?))", 'gi'
+    attributeRX = new RegExp "( ?)(\\#{attributeMarker}[ ]?(([\\w]+)(\\((.*?[^\\\\])\\))?))", 'gi'
     while match = attributeRX.exec checkLine
       sPt = new Point lineNumber, match.index
       ePt = new Point lineNumber, match.index + match[0].length
@@ -123,11 +123,13 @@ module.exports =
   addTag: (editor, lineNumber, attributeMarker, tagName, tagValue)->
     point = new Point lineNumber, editor.buffer.lineLengthForRow lineNumber
     if tagValue
-      editor.buffer.insert point, " #{attributeMarker}#{tagName}(#{tagValue})"
+      safeTagValue = @escapeTagValue tagValue
+      editor.buffer.insert point, " #{attributeMarker}#{tagName}(#{safeTagValue})"
     else
       editor.buffer.insert point, " #{attributeMarker}#{tagName}"
 
-
+  escapeTagValue: (tagValue) ->
+    tagValue.replace(/\(/g, "\\(").replace(/\)/g, "\\)")
 
   ###*
    * Helper for removing a tag by name
@@ -199,7 +201,6 @@ module.exports =
   ###
   getProjects: (editor, lineNumber)->
     lines = editor.tokenizedBuffer.tokenizedLines
-    checkLine = lines[lineNumber]
     projects = []
     curHeaderLevel = editor.indentationForBufferRow(lineNumber)
     return projects if lineNumber is 0

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "atom": ">= 1.13"
   },
   "dependencies": {
-    "moment": "~2.6.0",
+    "moment": "~2.11.2",
     "underscore": "^1.8.3"
   },
   "consumedServices": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tasks",
   "main": "./lib/tasks",
-  "version": "2.6.7",
+  "version": "2.7.0",
   "description": "Manage your todo lists",
   "keywords": [
     "tasks",

--- a/spec/sample.todo
+++ b/spec/sample.todo
@@ -1,5 +1,5 @@
 My Project:
   ☐ A **sample** task @tag1 and _something_ else [with](http://atom.io) url http://atom.io @tag2
-  ✔ A second task @tag1 things @done(2015-04-10 20:49) @project(My Project) ☐ marker mid task
+  ✔ A second **test** @tag1 _things_ @done(2015-04-10 20:49) @project(My Project) ☐ marker mid task
   not a real task
   ✘ A cancelled task @cancelled(2015-04-10 20:49) @project(My Project)

--- a/spec/sample.todo
+++ b/spec/sample.todo
@@ -1,5 +1,0 @@
-My Project:
-  ☐ A **sample** task @tag1 and _something_ else [with](http://atom.io) url http://atom.io @tag2
-  ✔ A second **test** @tag1 _things_ @done(2015-04-10 20:49) @project(My Project) ☐ marker mid task
-  not a real task
-  ✘ A cancelled task @cancelled(2015-04-10 20:49) @project(My Project)

--- a/spec/tasks-spec.coffee
+++ b/spec/tasks-spec.coffee
@@ -92,6 +92,19 @@ describe 'Tasks', ->
       line = editor.tokenizedBuffer.tokenizedLines[0]
       expect(line.tokens[6]).toEqual value: '1969-12-31 16:00', scopes: [doneTokens..., 'tasks.attribute.done', 'tasks.attribute-value']
 
+    it 'should convert to task', ->
+      editor.setText 'item'
+      Tasks.convertToTask()
+      line = editor.tokenizedBuffer.tokenizedLines[0]
+      expect(line.tokens[0]).toEqual value: '☐', scopes: [baseTokens..., 'keyword.tasks.marker']
+
+    it 'should convert to task with timestamp', ->
+      atom.config.set 'tasks.addTimestampOnConvertToTask', true
+      editor.setText 'item'
+      Tasks.convertToTask()
+      line = editor.tokenizedBuffer.tokenizedLines[0]
+      expect(line.tokens[5]).toEqual value: '1969-12-31 16:00', scopes: [baseTokens..., 'tasks.attribute.timestamp', 'tasks.attribute-value']
+
     it 'should archive completed tasks', ->
       editor.setText('''
       project:

--- a/spec/tasks-spec.coffee
+++ b/spec/tasks-spec.coffee
@@ -1,3 +1,4 @@
+path = require 'path'
 Tasks = require '../lib/tasks'
 tasksUtilities = require '../lib/tasksUtilities'
 [editor, buffer, grammar, workspaceElement] = []

--- a/spec/tasks-spec.coffee
+++ b/spec/tasks-spec.coffee
@@ -180,3 +180,29 @@ describe 'Tasks', ->
         it 'tokenizes a cancelled task', ->
           tokens = grammar.tokenizeLines('[-] text @cancelled()')
           expect(tokens[0][3]).toEqual value: 'cancelled', scopes: [cancelledTokens..., 'tasks.attribute.cancelled', 'tasks.attribute-name']
+
+  describe 'Escape', ->
+    beforeEach ->
+      editor.setText 'Project with (parens):\n  ☐ An incomplete task'
+      editor.setCursorBufferPosition [1,0]
+
+    describe 'should escape tag values', ->
+      it 'adds a project attribute', ->
+        Tasks.completeTask()
+
+        projectTag = tasksUtilities.getTag editor, 1, 'project', '@'
+
+        expect(projectTag).toBeDefined()
+        expect(projectTag.tagValue.value).toEqual("Project with \\(parens\\)")
+
+    describe 'should discard parenthesized done tags', ->
+      it 'adds a project attribute', ->
+        Tasks.completeTask()
+
+        projectTag = tasksUtilities.getTag editor, 1, 'project', '@'
+
+        # undo completion
+        Tasks.completeTask()
+
+        line = editor.getBuffer().lineForRow 1
+        expect(line).toMatch(/☐\s+An incomplete task\s*$/)

--- a/spec/tasks-spec.coffee
+++ b/spec/tasks-spec.coffee
@@ -1,256 +1,169 @@
 Tasks = require '../lib/tasks'
 tasksUtilities = require '../lib/tasksUtilities'
-[editor, buffer, workspaceElement] = []
+[editor, buffer, grammar, workspaceElement] = []
 
-find = (selector)->
-  workspaceElement.querySelectorAll "body /deep/ #{selector}"
+baseTokens = ['source.todo', 'tasks.text']
+doneTokens = ['source.todo', 'tasks.text.done']
+cancelledTokens = ['source.todo', 'tasks.text.cancelled']
 
 describe 'Tasks', ->
-###
   beforeEach ->
     waitsForPromise ->
-      atom.workspace.open('sample.todo').then (o) -> editor = o
-    runs ->
-      buffer = editor.getBuffer()
+      atom.workspace.open().then (o) -> editor = o
     waitsForPromise ->
-      atom.packages.activatePackage('language-gfm')
       atom.packages.activatePackage('tasks')
     runs ->
-      workspaceElement = atom.views.getView atom.workspace
-      jasmine.attachToDOM workspaceElement
+      grammar = atom.grammars.grammarForScopeName 'source.todo'
+      editor = atom.workspace.getActiveTextEditor()
+      editor.setGrammar grammar
 
   describe 'grammar should load', ->
     it 'loads', ->
-      grammar = atom.grammars.grammarForScopeName 'source.todo'
       expect(grammar).toBeDefined()
       expect(grammar.scopeName).toBe 'source.todo'
 
-  describe 'should syntax highlight a todo file', ->
-    it 'adds .marker to the markers', ->
-      expect(find('.marker').length).toBe 3
+  describe 'should tokenize', ->
+    it 'tokenizes a task', ->
+      tokens = grammar.tokenizeLines('☐ text @tag(test)')
+      expect(tokens[0][0]).toEqual value: '☐', scopes: [baseTokens..., 'keyword.tasks.marker']
+      expect(tokens[0][1]).toEqual value: ' text ', scopes: baseTokens
+      expect(tokens[0][2]).toEqual value: '@', scopes: [baseTokens..., 'tasks.attribute.tag']
+      expect(tokens[0][3]).toEqual value: 'tag', scopes: [baseTokens..., 'tasks.attribute.tag', 'tasks.attribute-name']
+      # skip (
+      expect(tokens[0][5]).toEqual value: 'test', scopes: [baseTokens..., 'tasks.attribute.tag', 'tasks.attribute-value']
 
-    it 'adds .attribute to @tags', ->
-      expect(find('.attribute').length).toBe 7
+    it 'tokenizes a project', ->
+      tokens = grammar.tokenizeLines('project:')
+      expect(tokens[0][0]).toEqual value: 'project', scopes: ['source.todo', 'control.tasks.header.project', 'control.tasks.header-title']
 
-    it 'adds .text to plain text', ->
-      expect(find('.text').length).toBe 3
+    it 'tokenizes a completed task', ->
+      tokens = grammar.tokenizeLines('✔ text @done()')
+      expect(tokens[0][3]).toEqual value: 'done', scopes: [doneTokens..., 'tasks.attribute.done', 'tasks.attribute-name']
 
-    it 'supports markdown in plain text', ->
-      expect(find('.bold').length).toBe 1
-      expect(find('.italic').length).toBe 1
-      expect(find('.link').length).toBe 2
+    it 'tokenizes a cancelled task', ->
+      tokens = grammar.tokenizeLines('✘ text @cancelled()')
+      expect(tokens[0][3]).toEqual value: 'cancelled', scopes: [cancelledTokens..., 'tasks.attribute.cancelled', 'tasks.attribute-name']
 
-  describe 'should be able to add new tasks', ->
-    it 'adds a new task', ->
+  describe 'manage tasks', ->
+    it 'creates a task below', ->
+      editor.setText '  ☐ item 1'
       Tasks.newTask()
-      editor.insertText 'Todo Item from tests'
-      line = editor.displayBuffer.tokenizedBuffer.tokenizedLines[1]
-      expect(find('.marker').length).toBe 4
-      expect(line.indentLevel).toBe 1
+      editor.insertText 'item 2'
+      line = editor.tokenizedBuffer.tokenizedLines[1]
+      expect(line.tokens[1]).toEqual value: '☐', scopes: [baseTokens..., 'keyword.tasks.marker']
+      expect(editor.indentationForBufferRow 1).toBe 1
 
-    it 'adds a new task above', ->
+    it 'creates a task above', ->
+      editor.setText '  ☐ item 1'
       Tasks.newTask(-1)
-      editor.insertText 'Todo Item from tests'
-      line = editor.displayBuffer.tokenizedBuffer.tokenizedLines[1]
-      expect(find('.marker').length).toBe 4
-      expect(line.indentLevel).toBe 0
+      editor.insertText 'item 2'
+      line = editor.tokenizedBuffer.tokenizedLines[0]
+      expect(line.tokens[1]).toEqual value: '☐', scopes: [baseTokens..., 'keyword.tasks.marker']
+      expect(editor.indentationForBufferRow 1).toBe 1
 
-  describe 'should be able to complete tasks', ->
-    it 'completes a task', ->
+    it 'completes tasks', ->
+      editor.setText 'project:\n  ☐ item 1'
       editor.setCursorBufferPosition [1,0]
       Tasks.completeTask()
-      doneTasks = tasksUtilities.getLinesByToken editor,
-        'tasks.text.done.source.gfm'
-      projectTasks = tasksUtilities.getLinesByToken editor,
-        'tasks.attribute.project'
+      line = editor.tokenizedBuffer.tokenizedLines[1]
+      expect(line.tokens[1]).toEqual value: '✔', scopes: [doneTokens..., 'keyword.tasks.marker']
+      expect(line.tokens[4]).toEqual value: 'done', scopes: [doneTokens..., 'tasks.attribute.done', 'tasks.attribute-name']
+      expect(line.tokens[12]).toEqual value: 'project', scopes: [doneTokens..., 'tasks.attribute.project', 'tasks.attribute-value']
 
-      expect(doneTasks.length).toBe 2
-      expect(projectTasks.length).toBe 3
-
-  describe 'should be able to cancel tasks', ->
-    it 'cancels a task', ->
+    it 'cancels tasks', ->
+      editor.setText 'project:\n  ☐ item 1'
       editor.setCursorBufferPosition [1,0]
       Tasks.cancelTask()
-      cancelled = tasksUtilities.getLinesByToken editor,
-        'tasks.text.cancelled.source.gfm'
-      projectTasks = tasksUtilities.getLinesByToken editor,
-        'tasks.attribute.project'
+      line = editor.tokenizedBuffer.tokenizedLines[1]
+      expect(line.tokens[1]).toEqual value: '✘', scopes: [cancelledTokens..., 'keyword.tasks.marker']
+      expect(line.tokens[4]).toEqual value: 'cancelled', scopes: [cancelledTokens..., 'tasks.attribute.cancelled', 'tasks.attribute-name']
+      expect(line.tokens[12]).toEqual value: 'project', scopes: [cancelledTokens..., 'tasks.attribute.project', 'tasks.attribute-value']
 
-      expect(cancelled.length).toBe 2
-      expect(projectTasks.length).toBe 3
-
-  describe 'should be able to set/update timestamps', ->
-    it 'adds a timestamp', ->
-      editor.setCursorBufferPosition [1,0]
+    it 'should add a timestamp', ->
+      editor.setText '  ☐ item 1'
       Tasks.setTimestamp()
-      timestampTag = tasksUtilities.getTag editor, 1, 'timestamp', '@'
-      expect(timestampTag).toBeDefined()
+      line = editor.tokenizedBuffer.tokenizedLines[0]
+      expect(line.tokens[4]).toEqual value: 'timestamp', scopes: [baseTokens..., 'tasks.attribute.timestamp', 'tasks.attribute-name']
+      expect(line.tokens[6]).toEqual value: '1969-12-31 16:00', scopes: [baseTokens..., 'tasks.attribute.timestamp', 'tasks.attribute-value']
 
     it 'should update a timestamp', ->
-      curDate = tasksUtilities.getFormattedDate()
-      editor.setCursorBufferPosition [2,0]
+      editor.setText '  ✔ item 1 @done(1970-1-1 0:00)'
       Tasks.setTimestamp()
-      doneTag = tasksUtilities.getTag editor, 2, 'done', '@'
-      expect(doneTag.tagValue.value).toBe(curDate)
+      line = editor.tokenizedBuffer.tokenizedLines[0]
+      expect(line.tokens[6]).toEqual value: '1969-12-31 16:00', scopes: [doneTokens..., 'tasks.attribute.done', 'tasks.attribute-value']
 
-  describe 'should be able to archive completed tasks', ->
-    it 'creates an archive section', ->
-      preText = editor.getText()
-      editor.setCursorBufferPosition [1,0]
-      Tasks.completeTask()
+    it 'should archive completed tasks', ->
+      editor.setText('''
+      project:
+        ☐ item 1
+        ✔ item 2 @done(1970-1-1 0:00) @project(project)
+      ''')
       Tasks.tasksArchive()
+      line = editor.tokenizedBuffer.tokenizedLines[3]
+      expect(line.tokens[0]).toEqual value: '＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿', scopes: ['source.todo']
+      line = editor.tokenizedBuffer.tokenizedLines[4]
+      expect(line.tokens[0]).toEqual value: 'Archive', scopes: ['source.todo', 'control.tasks.header.archive', 'control.tasks.header-title']
+      line = editor.tokenizedBuffer.tokenizedLines[5]
+      expect(line.tokens[2]).toEqual value: ' item 2 ', scopes: doneTokens
 
-      archive = tasksUtilities.getLinesByToken editor,
-        'tasks.header.archive'
-      expect(archive).toBeDefined()
-
-    it 'moves completed tasks', ->
-      preText = editor.getText()
-      editor.setCursorBufferPosition [1,0]
-      Tasks.completeTask()
+    it 'should archive cancelled tasks', ->
+      editor.setText('''
+      project:
+        ☐ item 1
+        ✘ item 2 @cancelled(1970-1-1 0:00) @project(project)
+      ''')
       Tasks.tasksArchive()
+      line = editor.tokenizedBuffer.tokenizedLines[5]
+      expect(line.tokens[2]).toEqual value: ' item 2 ', scopes: cancelledTokens
 
-      lines = editor.displayBuffer.tokenizedBuffer.tokenizedLines
-      line = lines[lines.length - 3]
-      hasCancelled = tasksUtilities.getToken line.tokens, 'tasks.text.done'
-
-      expect(hasCancelled).toBeDefined()
-
-    it 'moves cancelled tasks', ->
-      preText = editor.getText()
-      editor.setCursorBufferPosition [1,0]
-      Tasks.cancelTask()
-      Tasks.tasksArchive()
-
-      lines = editor.displayBuffer.tokenizedBuffer.tokenizedLines
-      line = lines[lines.length - 2]
-      hasCancelled = tasksUtilities.getToken line.tokens, 'tasks.text.cancelled'
-
-      expect(hasCancelled).toBeDefined()
-
-  describe 'helper methods should work', ->
-    it 'can add a tag with or without a value', ->
-      editor.setCursorBufferPosition [1,0]
-      lines = editor.displayBuffer.tokenizedBuffer.tokenizedLines
-
-      tasksUtilities.addTag editor, 1, '@', 'noval'
-
-      line = lines[1]
-      hasTag = tasksUtilities.getToken line.tokens, 'tasks.attribute.noval'
-      expect(hasTag).toBeDefined()
-
-      tasksUtilities.addTag editor, 1, '@', 'hasval', 'myvalue'
-
-      line = lines[1]
-      hasTag = tasksUtilities.getToken line.tokens, 'tasks.attribute.hasval'
-      expect(hasTag).toBeDefined()
-
-    it 'can update tag values', ->
-      editor.setCursorBufferPosition [1,0]
-      lines = editor.displayBuffer.tokenizedBuffer.tokenizedLines
-
-      tasksUtilities.addTag editor, 1, '@', 'original'
-
-      line = lines[1]
-      hasTag = tasksUtilities.getToken line.tokens, 'tasks.attribute.original'
-      expect(hasTag).toBeDefined()
-
-      tasksUtilities.updateTag editor, 1, '@', 'original', 'newval'
-      line = lines[1]
-      hasTag = tasksUtilities.getToken line.tokens, 'tasks.attribute-value'
-      expect(hasTag).toBeDefined()
-
-      tasksUtilities.updateTag editor, 1, '@', 'original'
-      line = lines[1]
-      hasTag = tasksUtilities.getToken line.tokens, 'tasks.attribute-value'
-      expect(hasTag).toBeNull()
-
-    it 'supports custom attribute markers', ->
-      atom.config.set 'tasks.attributeMarker', '#'
-      editor.setText '☐ Test'
-      tasksUtilities.addTag editor, 0, '#', 'test'
-
-      lines = editor.displayBuffer.tokenizedBuffer.tokenizedLines
-
-      hasTag = tasksUtilities.getToken lines[0].tokens, 'tasks.attribute.test'
-      expect(hasTag).toBeDefined()
-
-
-describe 'Taskpaper', ->
-
-  beforeEach ->
-    waitsForPromise ->
-      atom.workspace.open('sample.taskpaper').then (o) -> editor = o
-    runs ->
-      buffer = editor.getBuffer()
-    waitsForPromise ->
-      atom.packages.activatePackage('tasks')
-    runs ->
+  describe 'Taskpaper', ->
+    beforeEach ->
       atom.config.set 'tasks.baseMarker', '-'
       atom.config.set 'tasks.completeMarker', '-'
       atom.config.set 'tasks.cancelledMarker', '-'
-      workspaceElement = atom.views.getView atom.workspace
-      jasmine.attachToDOM workspaceElement
+      grammar = atom.grammars.grammarForScopeName 'source.todo'
+      editor.setGrammar grammar
 
-  describe 'should syntax highlight a taskpaper file', ->
-    it 'adds .marker to the markers', ->
-      expect(find('.marker').length).toBe 6
+    describe 'should tokenize', ->
+      it 'tokenizes a task', ->
+        tokens = grammar.tokenizeLines('- text @tag(test)')
+        expect(tokens[0][0]).toEqual value: '-', scopes: [baseTokens..., 'keyword.tasks.marker']
+        expect(tokens[0][1]).toEqual value: ' text ', scopes: baseTokens
+        expect(tokens[0][2]).toEqual value: '@', scopes: [baseTokens..., 'tasks.attribute.tag']
+        expect(tokens[0][3]).toEqual value: 'tag', scopes: [baseTokens..., 'tasks.attribute.tag', 'tasks.attribute-name']
+        # skip (
+        expect(tokens[0][5]).toEqual value: 'test', scopes: [baseTokens..., 'tasks.attribute.tag', 'tasks.attribute-value']
 
-    it 'adds .attribute to @tags', ->
-      expect(find('.attribute').length).toBe 2
+      it 'tokenizes a completed task', ->
+        tokens = grammar.tokenizeLines('- text @done()')
+        expect(tokens[0][3]).toEqual value: 'done', scopes: [doneTokens..., 'tasks.attribute.done', 'tasks.attribute-name']
 
-    it 'adds .text to plain text', ->
-      expect(find('.text').length).toBe 6
+      it 'tokenizes a cancelled task', ->
+        tokens = grammar.tokenizeLines('- text @cancelled()')
+        expect(tokens[0][3]).toEqual value: 'cancelled', scopes: [cancelledTokens..., 'tasks.attribute.cancelled', 'tasks.attribute-name']
 
-  describe 'should support the same marker for base, done, and cancelled', ->
-    it 'can complete a task', ->
-      editor.setCursorBufferPosition [1,0]
-      Tasks.completeTask()
+    describe 'Complex markers', ->
+      beforeEach ->
+        atom.config.set 'tasks.baseMarker', '[ ]'
+        atom.config.set 'tasks.completeMarker', '[x]'
+        atom.config.set 'tasks.cancelledMarker', '[-]'
+        grammar = atom.grammars.grammarForScopeName 'source.todo'
+        editor.setGrammar grammar
 
-      doneTasks = tasksUtilities.getLinesByToken editor,
-        'tasks.text.done.source.gfm'
-      projectTasks = tasksUtilities.getLinesByToken editor,
-        'tasks.attribute.project'
+      describe 'should tokenize', ->
+        it 'tokenizes a task', ->
+          tokens = grammar.tokenizeLines('[ ] text @tag(test)')
+          expect(tokens[0][0]).toEqual value: '[ ]', scopes: [baseTokens..., 'keyword.tasks.marker']
+          expect(tokens[0][1]).toEqual value: ' text ', scopes: baseTokens
+          expect(tokens[0][2]).toEqual value: '@', scopes: [baseTokens..., 'tasks.attribute.tag']
+          expect(tokens[0][3]).toEqual value: 'tag', scopes: [baseTokens..., 'tasks.attribute.tag', 'tasks.attribute-name']
+          # skip (
+          expect(tokens[0][5]).toEqual value: 'test', scopes: [baseTokens..., 'tasks.attribute.tag', 'tasks.attribute-value']
 
-      expect(doneTasks.length).toBe 1
-      expect(projectTasks.length).toBe 1
+        it 'tokenizes a completed task', ->
+          tokens = grammar.tokenizeLines('[x] text @done()')
+          expect(tokens[0][3]).toEqual value: 'done', scopes: [doneTokens..., 'tasks.attribute.done', 'tasks.attribute-name']
 
-describe 'Complex Markers', ->
-
-  beforeEach ->
-    waitsForPromise ->
-      atom.workspace.open('complexMarkers.todo').then (o) -> editor = o
-    runs ->
-      buffer = editor.getBuffer()
-    waitsForPromise ->
-      atom.packages.activatePackage('tasks')
-    runs ->
-      atom.config.set 'tasks.baseMarker', '[ ]'
-      atom.config.set 'tasks.completeMarker', '[x]'
-      atom.config.set 'tasks.cancelledMarker', '[-]'
-      workspaceElement = atom.views.getView atom.workspace
-      jasmine.attachToDOM workspaceElement
-
-  describe 'should syntax highlight a complex marker file', ->
-    it 'adds .marker to the markers', ->
-      expect(find('.marker').length).toBe 3
-
-    it 'adds .attribute to @tags', ->
-      expect(find('.attribute').length).toBe 1
-
-    it 'adds .text to plain text', ->
-      expect(find('.text').length).toBe 3
-
-  describe 'should support the same marker for base, done, and cancelled', ->
-    it 'can complete a task', ->
-      editor.setCursorBufferPosition [1,0]
-      Tasks.completeTask()
-
-      doneTasks = tasksUtilities.getLinesByToken editor,
-        'tasks.text.done.source.gfm'
-      projectTasks = tasksUtilities.getLinesByToken editor,
-        'tasks.attribute.project'
-
-      expect(doneTasks.length).toBe 1
-      expect(projectTasks.length).toBe 1
-###
+        it 'tokenizes a cancelled task', ->
+          tokens = grammar.tokenizeLines('[-] text @cancelled()')
+          expect(tokens[0][3]).toEqual value: 'cancelled', scopes: [cancelledTokens..., 'tasks.attribute.cancelled', 'tasks.attribute-name']


### PR DESCRIPTION
per [Proposal, require that both ( and ) are always escaped in tag values?](http://support.hogbaysoftware.com/t/proposal-require-that-both-and-are-always-escaped-in-tag-values/1820) (Hog Bay TaskPaper support), to fix #74 

Escape parens when adding a tag with a value (among others, collected project names when marking an item done). Look for an *unescaped* right paren when retrieving a tag's value.