### PR TITLE
fix markdown in text, fix completion in taskbar

### DIFF
--- a/lib/tasks.cson
+++ b/lib/tasks.cson
@@ -16,7 +16,7 @@
   {
     'begin': '^([\\s]*)(✔)(?=.*@done)'
     'end': '$'
-    'name': 'tasks.text.done.md'
+    'name': 'tasks.text.done'
     'beginCaptures':
       '2': 'name': 'keyword.tasks.marker'
     'patterns': [
@@ -27,26 +27,25 @@
   {
     'begin': '^([\\s]*)(✘)(?=.*@cancelled)'
     'end': '$'
-    'name': 'tasks.text.cancelled.md'
+    'name': 'tasks.text.cancelled'
     'beginCaptures':
       '2': 'name': 'keyword.tasks.marker'
     'patterns': [
-      {'include': '#marker'}
       {'include': '#attribute'}
     ]
   }
 
   {
-    'match': '^([\\s]*)(☐)((?:(?!:$).)*)$'
-    'name': 'tasks.text.md'
-    'captures':
+    'begin': '^([\\s]*)(☐)'
+    'end': '$'
+    'name': 'tasks.text'
+    'beginCaptures':
       '2': 'name': 'keyword.tasks.marker'
-      '3':
-        'patterns': [
-          {'include': '#attribute'}
-          {'include': 'text.md'}
-          {'include': 'text.hyperlink'}
-        ]
+    'patterns': [
+      {'include': '#attribute'},
+      {'include': 'text.md'}
+      {'include': 'text.hyperlink'}
+    ]
   }
 ]
 

--- a/lib/tasksUtilities.coffee
+++ b/lib/tasksUtilities.coffee
@@ -7,8 +7,8 @@ moment = require 'moment'
 module.exports =
 
   markerSelector: 'keyword.tasks.marker'
-  doneSelector: 'tasks.text.done.source.gfm'
-  cancelledSelector: 'tasks.text.cancelled.source.gfm'
+  doneSelector: 'tasks.text.done'
+  cancelledSelector: 'tasks.text.cancelled'
   archiveSelector: 'control.tasks.header.archive'
   headerSelector: 'control.tasks.header-title'
 
@@ -212,7 +212,7 @@ module.exports =
 
         rowIsZero = editor.indentationForBufferRow(row) is 0
         rowIsEmpty = editor.isBufferRowBlank(row)
-          
+
         break if rowIsZero and not rowIsEmpty
     projects
 

--- a/spec/sample.todo
+++ b/spec/sample.todo
@@ -1,5 +1,5 @@
 My Project:
   ☐ A **sample** task @tag1 and _something_ else [with](http://atom.io) url http://atom.io @tag2
-  ✔ A second task @tag1 things @done(2015-04-10 20:49) @project(My Project) ☐ marker mid task
+  ✔ A second **test** @tag1 _things_ @done(2015-04-10 20:49) @project(My Project) ☐ marker mid task
   not a real task
   ✘ A cancelled task @cancelled(2015-04-10 20:49) @project(My Project)


### PR DESCRIPTION
Currently there are two issues referenced here. One is that markdown highlighting is inconsistent. The other is that the counting of completed vs total tasks is inaccurate. This is primarily due to a mismatch with the class being attached to the line item vs what's being looked for in the code. The markdown fix just comes along for the ride with a minor tweak.

@paulroub: how do you feel about these changes?

This is also a reference to #83 