### PR TITLE
Correct Auto Indentation

### DIFF
--- a/lib/tasks.coffee
+++ b/lib/tasks.coffee
@@ -206,8 +206,6 @@ module.exports =
       editor.insertNewlineAbove() if direction is -1
       editor.insertText "#{marker} "
 
-      editor.indentSelectedRows() if info.type is 'project' and direction is 1
-
 
 
   ###*

--- a/settings/tasks.cson
+++ b/settings/tasks.cson
@@ -1,0 +1,4 @@
+'.source.todo, .source.taskpaper':
+  'editor':
+    'autoIndentOnPaste': false
+    'increaseIndentPattern': '^.*:$'


### PR DESCRIPTION
I've noticed that moving around the first line in a project does not indent consistently.
![jan-04-2018 21-35-32](https://user-images.githubusercontent.com/316502/34590973-f0c6679a-f198-11e7-8796-bb888de76c63.gif)

This change adds a file to control that. It also fixes selecting a bunch of content and auto-indenting the selection.